### PR TITLE
Fix link error in sidebar.markdown

### DIFF
--- a/_includes/content/sidebar.markdown
+++ b/_includes/content/sidebar.markdown
@@ -57,7 +57,7 @@
 * [The QEMU plug-in]({{ site.baseurl }}/debug/qemu/)
 * [The peripheral registers view (CMSIS)]({{ site.baseurl }}/debug/peripheral-registers/)
 
-#### [GNU MCU ARM GCC]({{ site.baseurl }}/toolchain/riscv/)
+#### [GNU MCU ARM GCC]({{ site.baseurl }}/toolchain/arm/)
 
 * [Overview]({{ site.baseurl }}/toolchain/arm/)
 * [ARM Toolchain(s) install]({{ site.baseurl }}/toolchain/arm/install/)


### PR DESCRIPTION
Top level link to the arm toolchain was pointing to the risks one.